### PR TITLE
bump meow

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "is-finite": "^1.0.0",
-    "meow": "^1.0.0"
+    "meow": "^2.0.0"
   },
   "devDependencies": {
     "ava": "0.0.4"


### PR DESCRIPTION
meow installs outdated meow.

``` sh
$ npm outdated
meow                   1.0.0   1.0.0   2.0.0  meow > indent-string > repeating > meow
```
